### PR TITLE
Add important clarification on custom detectors to help #140

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,3 +130,5 @@ export default {
       detection: options
     });
 ```
+
+Don't forget: You have to add the name of your detector (`myDetectorsName` in this case) to the `order` array in your `options` object. Without that, your detector won't be used. See the [Detector Options section for more](#detector-options).


### PR DESCRIPTION
Without this important note people won't realize why their custom detector doesn't work until the look into the source code. This small note can save hours of head scratching.