### PR TITLE
Further specify the querystring method

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This is a i18next language detection plugin use to detect user language in the b
 - cookie
 - localStorage
 - navigator
-- querystring
+- querystring (append `?lng=LANGUAGE` to URL)
 - htmlTag
 
 # Getting started


### PR DESCRIPTION
This method is the quickest for debugging and previously required tribal knowledge or source-code sifting to find the `lng` keyword. Now it's easier to find for folks using this for the first time.