### PR TITLE
Lang by path: skip if language not found

### DIFF
--- a/src/browserLookups/path.js
+++ b/src/browserLookups/path.js
@@ -7,6 +7,9 @@ export default {
       const language = window.location.pathname.match(/\/([a-zA-Z-]*)/g);
       if (language instanceof Array) {
         if (typeof options.lookupFromPathIndex === 'number') {
+          if (typeof language[options.lookupFromPathIndex]) {
+            return undefined;
+          }
           found = language[options.lookupFromPathIndex].replace('/', '');
         } else {
           found = language[0].replace('/', '');


### PR DESCRIPTION
Skip language detection by path if the language could not be found.

Happens when whitelisting languages or when visiting index pages (w/o lang path)