### PR TITLE
feat: exclude detectors from lookup

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ As with all modules you can either pass the constructor function (class) to the 
   // cache user language on
   caches: ['localStorage', 'cookie'],
   excludeCacheFor: ['cimode'], // languages to not persist (cookie, localStorage)
+  excludeLookupFor: ['navigator', 'htmlTag'], // you can exclude detectors to avoid lookup for them
 
   // optional expire and domain for set cookie
   cookieMinutes: 10,

--- a/src/index.js
+++ b/src/index.js
@@ -13,10 +13,10 @@ function getDefaults() {
     lookupQuerystring: 'lng',
     lookupCookie: 'i18next',
     lookupLocalStorage: 'i18nextLng',
-
     // cache user language
     caches: ['localStorage'],
     excludeCacheFor: ['cimode'],
+    excludeLookupFor: [],
     //cookieMinutes: 10,
     //cookieDomain: 'myDomain'
     checkWhitelist: true,

--- a/src/index.js
+++ b/src/index.js
@@ -51,6 +51,10 @@ class Browser {
   }
 
   addDetector(detector) {
+    if (this.options.excludeLookupFor.includes(detector.name)) {
+      return delete this.detectors[detector.name];
+    }
+
     this.detectors[detector.name] = detector;
   }
 


### PR DESCRIPTION
It would be very handy to have the ability to exclude lookups for specific detectors.
In my project lookup for language in navigator might lead to undesirable results, unfortunately I haven't found an option to disable lookup in navigator.
Could you checkout my pr and consider to merge it?
Or maybe I am missing something and you can suggest how I can avoid lookup in window.navigator?