### PR TITLE
typo in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ As with all modules you can either pass the constructor function (class) to the 
   htmlTag: document.documentElement,
 
   // only detect languages that are in the whitelist
-  checkWhitelist: true
+  checkWhitelist: true,
     // optional set cookie options, reference:[MDN Set-Cookie docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie)
   cookieOptions: {path:'/'}
 }


### PR DESCRIPTION
tiny typo fix to make the example work immediately when copy-pasted.