### PR TITLE
Validate localStorage and sessionStorage only if I use these resources

### DIFF
--- a/src/browserLookups/localStorage.js
+++ b/src/browserLookups/localStorage.js
@@ -1,6 +1,8 @@
 let hasLocalStorageSupport = null;
 
 const localStorageAvailable = () => {
+  if (hasLocalStorageSupport !== null) return hasLocalStorageSupport;
+
   try {
     hasLocalStorageSupport = window !== 'undefined' && window.localStorage !== null;
     const testKey = 'i18next.translate.boo';
@@ -12,18 +14,13 @@ const localStorageAvailable = () => {
   return hasLocalStorageSupport;
 }
 
-const checkLocalStorage = () => {
-  if (hasLocalStorageSupport === null) hasLocalStorageSupport = localStorageAvailable();
-}
-
 export default {
   name: 'localStorage',
 
   lookup(options) {
     let found;
-    checkLocalStorage();
 
-    if (options.lookupLocalStorage && hasLocalStorageSupport) {
+    if (options.lookupLocalStorage && localStorageAvailable()) {
       const lng = window.localStorage.getItem(options.lookupLocalStorage);
       if (lng) found = lng;
     }
@@ -32,9 +29,7 @@ export default {
   },
 
   cacheUserLanguage(lng, options) {
-    checkLocalStorage();
-
-    if (options.lookupLocalStorage && hasLocalStorageSupport) {
+    if (options.lookupLocalStorage && localStorageAvailable()) {
       window.localStorage.setItem(options.lookupLocalStorage, lng);
     }
   }

--- a/src/browserLookups/localStorage.js
+++ b/src/browserLookups/localStorage.js
@@ -1,11 +1,14 @@
-let hasLocalStorageSupport;
-try {
-  hasLocalStorageSupport = window !== 'undefined' && window.localStorage !== null;
-  const testKey = 'i18next.translate.boo';
-  window.localStorage.setItem(testKey, 'foo');
-  window.localStorage.removeItem(testKey);
-} catch (e) {
-  hasLocalStorageSupport = false;
+const localStorageAvailable = () => {
+  let hasLocalStorageSupport;
+  try {
+    hasLocalStorageSupport = window !== 'undefined' && window.localStorage !== null;
+    const testKey = 'i18next.translate.boo';
+    window.localStorage.setItem(testKey, 'foo');
+    window.localStorage.removeItem(testKey);
+  } catch (e) {
+    hasLocalStorageSupport = false;
+  }
+  return hasLocalStorageSupport;
 }
 
 export default {
@@ -14,7 +17,7 @@ export default {
   lookup(options) {
     let found;
 
-    if (options.lookupLocalStorage && hasLocalStorageSupport) {
+    if (options.lookupLocalStorage && localStorageAvailable()) {
       const lng = window.localStorage.getItem(options.lookupLocalStorage);
       if (lng) found = lng;
     }
@@ -23,7 +26,7 @@ export default {
   },
 
   cacheUserLanguage(lng, options) {
-    if (options.lookupLocalStorage && hasLocalStorageSupport) {
+    if (options.lookupLocalStorage && localStorageAvailable()) {
       window.localStorage.setItem(options.lookupLocalStorage, lng);
     }
   }

--- a/src/browserLookups/localStorage.js
+++ b/src/browserLookups/localStorage.js
@@ -1,5 +1,6 @@
+let hasLocalStorageSupport = null;
+
 const localStorageAvailable = () => {
-  let hasLocalStorageSupport;
   try {
     hasLocalStorageSupport = window !== 'undefined' && window.localStorage !== null;
     const testKey = 'i18next.translate.boo';
@@ -11,13 +12,18 @@ const localStorageAvailable = () => {
   return hasLocalStorageSupport;
 }
 
+const checkLocalStorage = () => {
+  if (hasLocalStorageSupport === null) hasLocalStorageSupport = localStorageAvailable();
+}
+
 export default {
   name: 'localStorage',
 
   lookup(options) {
     let found;
+    checkLocalStorage();
 
-    if (options.lookupLocalStorage && localStorageAvailable()) {
+    if (options.lookupLocalStorage && hasLocalStorageSupport) {
       const lng = window.localStorage.getItem(options.lookupLocalStorage);
       if (lng) found = lng;
     }
@@ -26,7 +32,9 @@ export default {
   },
 
   cacheUserLanguage(lng, options) {
-    if (options.lookupLocalStorage && localStorageAvailable()) {
+    checkLocalStorage();
+
+    if (options.lookupLocalStorage && hasLocalStorageSupport) {
       window.localStorage.setItem(options.lookupLocalStorage, lng);
     }
   }

--- a/src/browserLookups/sessionStorage.js
+++ b/src/browserLookups/sessionStorage.js
@@ -1,5 +1,6 @@
+let hasSessionStorageSupport = null;
+
 const sessionStorageAvailable = () => {
-  let hasSessionStorageSupport;
   try {
     hasSessionStorageSupport = window !== 'undefined' && window.sessionStorage !== null;
     const testKey = 'i18next.translate.boo';
@@ -11,13 +12,18 @@ const sessionStorageAvailable = () => {
   return hasSessionStorageSupport;
 }
 
+const checkSessionStorage = () => {
+  if (hasSessionStorageSupport === null) hasSessionStorageSupport = sessionStorageAvailable();
+}
+
 export default {
   name: 'sessionStorage',
 
   lookup(options) {
     let found;
+    checkSessionStorage();
 
-    if (options.lookupSessionStorage && sessionStorageAvailable()) {
+    if (options.lookupSessionStorage && hasSessionStorageSupport) {
       const lng = window.sessionStorage.getItem(options.lookupSessionStorage);
       if (lng) found = lng;
     }
@@ -26,7 +32,9 @@ export default {
   },
 
   cacheUserLanguage(lng, options) {
-    if (options.lookupSessionStorage && sessionStorageAvailable()) {
+    checkSessionStorage();
+    
+    if (options.lookupSessionStorage && hasSessionStorageSupport) {
       window.sessionStorage.setItem(options.lookupSessionStorage, lng);
     }
   }

--- a/src/browserLookups/sessionStorage.js
+++ b/src/browserLookups/sessionStorage.js
@@ -1,6 +1,8 @@
 let hasSessionStorageSupport = null;
 
 const sessionStorageAvailable = () => {
+  if (hasSessionStorageSupport !== null) return hasSessionStorageSupport;
+
   try {
     hasSessionStorageSupport = window !== 'undefined' && window.sessionStorage !== null;
     const testKey = 'i18next.translate.boo';
@@ -12,18 +14,13 @@ const sessionStorageAvailable = () => {
   return hasSessionStorageSupport;
 }
 
-const checkSessionStorage = () => {
-  if (hasSessionStorageSupport === null) hasSessionStorageSupport = sessionStorageAvailable();
-}
-
 export default {
   name: 'sessionStorage',
 
   lookup(options) {
     let found;
-    checkSessionStorage();
 
-    if (options.lookupSessionStorage && hasSessionStorageSupport) {
+    if (options.lookupSessionStorage && sessionStorageAvailable()) {
       const lng = window.sessionStorage.getItem(options.lookupSessionStorage);
       if (lng) found = lng;
     }
@@ -32,9 +29,7 @@ export default {
   },
 
   cacheUserLanguage(lng, options) {
-    checkSessionStorage();
-    
-    if (options.lookupSessionStorage && hasSessionStorageSupport) {
+    if (options.lookupSessionStorage && sessionStorageAvailable()) {
       window.sessionStorage.setItem(options.lookupSessionStorage, lng);
     }
   }

--- a/src/browserLookups/sessionStorage.js
+++ b/src/browserLookups/sessionStorage.js
@@ -1,11 +1,14 @@
-let hasSessionStorageSupport;
-try {
-  hasSessionStorageSupport = window !== 'undefined' && window.sessionStorage !== null;
-  const testKey = 'i18next.translate.boo';
-  window.sessionStorage.setItem(testKey, 'foo');
-  window.sessionStorage.removeItem(testKey);
-} catch (e) {
-  hasSessionStorageSupport = false;
+const sessionStorageAvailable = () => {
+  let hasSessionStorageSupport;
+  try {
+    hasSessionStorageSupport = window !== 'undefined' && window.sessionStorage !== null;
+    const testKey = 'i18next.translate.boo';
+    window.sessionStorage.setItem(testKey, 'foo');
+    window.sessionStorage.removeItem(testKey);
+  } catch (e) {
+    hasSessionStorageSupport = false;
+  }
+  return hasSessionStorageSupport;
 }
 
 export default {
@@ -14,7 +17,7 @@ export default {
   lookup(options) {
     let found;
 
-    if (options.lookupSessionStorage && hasSessionStorageSupport) {
+    if (options.lookupSessionStorage && sessionStorageAvailable()) {
       const lng = window.sessionStorage.getItem(options.lookupSessionStorage);
       if (lng) found = lng;
     }
@@ -23,7 +26,7 @@ export default {
   },
 
   cacheUserLanguage(lng, options) {
-    if (options.lookupSessionStorage && hasSessionStorageSupport) {
+    if (options.lookupSessionStorage && sessionStorageAvailable()) {
       window.sessionStorage.setItem(options.lookupSessionStorage, lng);
     }
   }


### PR DESCRIPTION
Our application is not using sessionStorage or localStorage.

`hasLocalStorageSupport` and `hasSessionStorageSupport` validates if browser has support to these resources.

However, `sessionStorage.setItem` and `localStorage.setItem` are called in the import and I don't want that because my application cannot have any kind of cookies, sessionStorage or localStorage.

Although it's removed right after, history is there to let users know some kind of cookie was added:

<img width="313" alt="cookies" src="https://user-images.githubusercontent.com/4612887/90542190-1c84e880-e15a-11ea-8a7b-f58fed200273.png">
<img width="445" alt="cookies-history" src="https://user-images.githubusercontent.com/4612887/90542206-1ee74280-e15a-11ea-882f-e65208e37286.png">

This fix avoid this scenario:

<img width="313" alt="no-cookies" src="https://user-images.githubusercontent.com/4612887/90542211-21499c80-e15a-11ea-99ac-581945f54f71.png">

#### Checklist

- [ x ] only relevant code is changed (make a diff before you submit the PR)
- [ x ] run tests `npm run test`
- [ n/a ] tests are included
- [ n/a ] documentation is changed or added