### PR TITLE
Improve developer ergonomics for defining a CustomDetector in TS by making types available

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,6 @@
 import * as i18next from 'i18next';
 
-interface DetectorOptions {
+export type interface DetectorOptions {
   /**
    * order and from where user language should be detected
    */
@@ -42,7 +42,7 @@ interface DetectorOptions {
   htmlTag?: HTMLElement | null;
 }
 
-interface CustomDetector {
+export type interface CustomDetector {
   name: string;
   cacheUserLanguage?(lng: string, options: DetectorOptions): void;
   lookup(options: DetectorOptions): string | undefined;


### PR DESCRIPTION
Personally I don't like flying blind, and right now it would be a major hassle to access these types via `I18nextBrowserLanguageDetector` indirectly. But maybe I'm holding it wrong. As this is only exporting types, this shouldn't be an API breaking change, but it requires Typescript 3.8 from my understanding.

#### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [ ] run tests `npm run test` (I did not, I changed this right here in GitHub)
- [x] tests are included
- [ ] documentation is changed or added