### PR TITLE
Documentation: include supportedLngs in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,10 +33,15 @@ Wiring up:
 import i18next from 'i18next';
 import LanguageDetector from 'i18next-browser-languagedetector';
 
-i18next.use(LanguageDetector).init(i18nextOptions);
+i18next.use(LanguageDetector).init({
+  supportedLngs: ['de', 'en', 'fr'],
+  ...i18nextOptions
+});
 ```
 
 As with all modules you can either pass the constructor function (class) to the i18next.use or a concrete instance.
+
+[`supportedLngs`](https://www.i18next.com/overview/configuration-options#languages-namespaces-resources) is optional, but allows i18next to pick the best match from the list of detected languages. If it's not set then [`language`](https://www.i18next.com/overview/api#language) will be set to the first detected language, regardless of whether your application has translations for that language or not.   
 
 ## Detector Options
 *The default options can be found [here](https://github.com/i18next/i18next-browser-languageDetector/blob/9efebe6ca0271c3797bc09b84babf1ba2d9b4dbb/src/index.js#L11).*


### PR DESCRIPTION
Clarify that how the list of detected languages is used by i18next is dependent on the value of `supportedLngs`.

This wasn't clear to me from the existing documentation - the only reference I could find to that config option was in [the big list of config options](https://www.i18next.com/overview/configuration-options), and the description there doesn't refer to detection.

As discussed in issue https://github.com/i18next/i18next-browser-languageDetector/issues/283

#### Checklist (for documentation change)

- [x] only relevant documentation part is changed (make a diff before you submit the PR)
- [x] motivation/reason is provided
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)