### PR TITLE
chore: set browsers target to `defaults`

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,12 @@
 {
-  "presets": ["@babel/env"]
+  "presets": [
+    [
+      "@babel/env",
+      {
+        "targets": {
+          "browsers": ["defaults"]
+        }
+      }
+    ]
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -82,9 +82,6 @@
   "tsd": {
     "directory": "test/typescript"
   },
-  "browserslist": [
-    "fully supports es6"
-  ],
   "author": "Jan Mühlemann <jan.muehlemann@gmail.com> (https://github.com/jamuhl)",
   "license": "MIT"
 }

--- a/package.json
+++ b/package.json
@@ -82,6 +82,9 @@
   "tsd": {
     "directory": "test/typescript"
   },
+  "browserslist": [
+    "fully supports es6"
+  ],
   "author": "Jan Mühlemann <jan.muehlemann@gmail.com> (https://github.com/jamuhl)",
   "license": "MIT"
 }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

Technically a breaking change but I believe it makes sense to only support es6 supported browsers which get's rid of a lot of the polyfills that babel need to insert which is inflating the bundle a lot. It also allows babel to use object deconstruction internally in the transformers and other newer syntax so further reduce the bundle.

The minified file in the top level of the repo went from `7 540 byte` to `6 341 byte`. A reduction of ~16%.

ES6 is supported by 97.1% of the browsers right now: https://browsersl.ist/#q=%22browserslist%22%3A+%5B%0A++++++++%22fully+supports+es6%22%0A++++++%5D

I didn't see any reference to which browsers or JS versions that are supported so I don't believe this requires any documentation updates but please let me know if it does.

PS: If you prefer this as a option inside the `.babelrc` file instead I'd be happy to change it but in general I think it's best to set it in the `package.json` so all tooling picks it up.

#### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] run tests `npm run test`
- [x] tests are included
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)

#### Checklist (for documentation change)

- [x] only relevant documentation part is changed (make a diff before you submit the PR)
- [x] motivation/reason is provided
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)