### PR TITLE
feat: add support for Partitioned cookies

### DIFF
--- a/src/browserLookups/cookie.js
+++ b/src/browserLookups/cookie.js
@@ -49,6 +49,7 @@ const serializeCookie = (name, val, options = { path: '/' }) => {
         throw new TypeError('option sameSite is invalid');
     }
   }
+  if (opt.partitioned) str += '; Partitioned';
   return str;
 };
 


### PR DESCRIPTION
Support for the `Partitioned` cookie attribute. This allows developers to take advantage of [partitioned cookies](https://developer.chrome.com/blog/partitioned-cookies/) when setting a language cookie via `i18next-browser-languageDetector`, which is useful in embedded or cross-site scenarios.
 
#### Checklist
 
- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] run tests `npm run test`
- [x] tests are included
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)